### PR TITLE
Info panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v1.1.3
+#### Fixed
+- Fixed a minor styling bug involving the Panel component's behavior on hover
+
 ### v1.1.2
 #### Updated
 - Added additional configuration options to the Panel component

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "library-simplified-reusable-components",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Reusable React components for Library Simplified interfaces",
   "repository": {
     "type": "git",

--- a/src/stylesheets/panel.scss
+++ b/src/stylesheets/panel.scss
@@ -59,9 +59,9 @@
 .panel-instruction {
   .panel-heading {
     background: darken($blue-tint, 10);
-    &:not(.static-panel) > .panel-heading:hover {
-      background: $blue;
-    }
+  }
+  &:not(.static-panel) > .panel-heading:hover {
+    background: $blue;
   }
 }
 


### PR DESCRIPTION
Mystery solved; I had a bracket in the wrong place.

It doesn't seem worth it to me to publish a whole new version number just for this.  @EdwinGuzman, is your Storybook branch close enough to finished that we could stick this change in with it (and maybe also update the Storybook documentation to include this style of panel)?

<img width="677" alt="Screen Shot 2019-04-04 at 11 43 53 AM" src="https://user-images.githubusercontent.com/42178216/55569283-49ed0580-56cf-11e9-9961-4ccdb9ee9ab6.png">
