### PR TITLE
Fix inverted button text color on focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v1.3.2
+#### Fixed
+- Fixed Button styling bug involving text color on focus.
+
 ### v1.3.1
 - Added additional configuration options to the Button component.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "library-simplified-reusable-components",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Reusable React components for Library Simplified interfaces",
   "repository": {
     "type": "git",

--- a/src/stylesheets/button.scss
+++ b/src/stylesheets/button.scss
@@ -25,7 +25,7 @@ button.btn, a.btn {
       transition: fill .5s;
     }
   }
-  &:focus {
+  &:focus:not(.inverted) {
     color: $white;
   }
   &:disabled {


### PR DESCRIPTION
Extremely minor styling bug: text color on buttons with class "inverted" should not turn white (i.e. become invisible) on focus.
<img width="377" alt="Screen Shot 2019-04-25 at 4 16 05 PM" src="https://user-images.githubusercontent.com/42178216/56766230-ece8ea80-6776-11e9-85ae-2bc454e0abc1.png">

[JIRA](https://jira.nypl.org/browse/SIMPLY-1892)