### PR TITLE
Panel props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### v1.3.2
 - Enabled optional specification of custom behavior on enter for the Panel component.
+- Enabled Panel component to recalculate its display on changes to the openByDefault prop.
 
 ### v1.3.1
 - Added additional configuration options to the Button component.

--- a/__tests__/components/Panel-test.tsx
+++ b/__tests__/components/Panel-test.tsx
@@ -130,4 +130,17 @@ describe("Panel", () => {
     expect(onEnter.callCount).to.equal(1);
   });
 
+  it("should update its display if the openByDefault prop changes", () => {
+    expect(wrapper.state()["display"]).to.equal("collapse");
+    wrapper.setProps({ openByDefault: true });
+    expect(wrapper.state()["display"]).to.equal("");
+  });
+
+  it("should not update its display if it is not collapsible", () => {
+    wrapper.setProps({ collapsible: false });
+    expect(wrapper.state()["display"]).to.equal("");
+    wrapper.setProps({ openByDefault: true });
+    expect(wrapper.state()["display"]).to.equal("");
+  });
+
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "library-simplified-reusable-components",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/components/Panel.tsx
+++ b/src/components/Panel.tsx
@@ -42,8 +42,19 @@ export default class Panel extends React.Component<PanelOwnProps, PanelState> {
     this.renderHeader = this.renderHeader.bind(this);
     this.toggle = this.toggle.bind(this);
     this.overrideEnter = this.overrideEnter.bind(this);
-    let display = (this.props.openByDefault || !this.props.collapsible) ? "" : "collapse";
-    this.state = { display };
+    this.state = { display: this.calculateDisplay(props) };
+  }
+
+  calculateDisplay(props: PanelOwnProps): string {
+    let display: string;
+    // If the panel isn't collapsible, that overrides everything else.
+    if (!props.collapsible) {
+      display = "";
+    }
+    else {
+      display = props.openByDefault ? "" : "collapse";
+    }
+    return display;
   }
 
   toggle(e) {
@@ -57,8 +68,7 @@ export default class Panel extends React.Component<PanelOwnProps, PanelState> {
   }
 
   componentWillReceiveProps(newProps) {
-    let display = newProps.openByDefault ? "" : "collapse";
-    this.props.collapsible && this.setState({...this.state, display });
+    this.setState({...this.state, display: this.calculateDisplay(newProps)});
   }
 
   renderHeader(): JSX.Element {

--- a/src/components/Panel.tsx
+++ b/src/components/Panel.tsx
@@ -56,6 +56,11 @@ export default class Panel extends React.Component<PanelOwnProps, PanelState> {
     this.props.onEnter && this.props.onEnter();
   }
 
+  componentWillReceiveProps(newProps) {
+    let display = newProps.openByDefault ? "" : "collapse";
+    this.props.collapsible && this.setState({...this.state, display });
+  }
+
   renderHeader(): JSX.Element {
     let title = <span className="panel-title">{this.props.headerText}</span>;
     let iconName = this.state.display === "collapse" ? "down-icon" : "up-icon";


### PR DESCRIPTION
Enable the Panel to recalculate its display when it receives new props.  (This was motivated by the UI for registry_admin's [new search feature](https://jira.nypl.org/browse/SIMPLY-1887), whereby the panel containing the search result should automatically open, but there's no problem with merging/publishing by itself rather than waiting for the other repos' search result implementations to be in.)

NOTE: the registry_admin's search feature has changed such that it no longer needs to use this branch, but I think this functionality is still worth having.