### PR TITLE
Adding withInfo Storybook addon for better documentation.

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,6 +1,25 @@
+import * as React from 'react';
 import { configure, addDecorator } from '@storybook/react';
+import { withInfo } from '@storybook/addon-info';
+import { withKnobs } from '@storybook/addon-knobs';
+import { withA11y } from '@storybook/addon-a11y';
 
-// Automatically import all files ending in *.stories.tsx
+import '../node_modules/bootstrap/dist/css/bootstrap.min.css';
+import '../src/stylesheets/app.scss';
+import './storybook.scss';
+
+const styles = {
+  padding: '20px',
+};
+export const CenterDecorator = storyFn => <div style={styles}>{storyFn()}</div>;
+
+addDecorator(withInfo);
+addDecorator(CenterDecorator);
+addDecorator(withKnobs);
+addDecorator(withA11y);
+
+// Automatically import all files ending in *.stories.tsx but first
+// load the introduction story.
 const req = require.context('../stories', true, /\.stories\.tsx$/);
 function loadStories() {
   require('../stories/index.stories');

--- a/.storybook/storybook.scss
+++ b/.storybook/storybook.scss
@@ -1,0 +1,13 @@
+/**
+ * Storybook style overrides
+ */
+
+// To make the `withInfo` proptype table readable.
+table {
+  border: 1px solid;
+
+  th, td {
+    padding: 5px;
+    border: 1px solid;
+  }
+}

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -2,7 +2,10 @@ module.exports = async ({ config }) => {
   config.module.rules = config.module.rules.concat([
     {
       test: /\.(ts|tsx)$/,
-      loader: 'ts-loader'
+      loaders: [
+        'ts-loader',
+        'react-docgen-typescript-loader'
+      ]
     },
     {
       test: /\.stories\.tsx?$/,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v1.3.4
+#### Added
+- Added `withInfo` Storybook addon to include better documentation for each component.
+
 ### v1.3.3
 #### Fixed
 - Color Contrast issue for the "danger" button style.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "library-simplified-reusable-components",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1276,6 +1276,29 @@
         "uuid": "3.3.2"
       }
     },
+    "@storybook/addon-info": {
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-info/-/addon-info-5.0.11.tgz",
+      "integrity": "sha512-lAz0zranutGXtoBbKLIGA4nOlb9YfSDu24A3uR6Q743LTo/SWUiZW14E+JkBkNI/oReev8DyvMSL26t8Z9RlfA==",
+      "dev": true,
+      "requires": {
+        "@storybook/addons": "5.0.11",
+        "@storybook/client-logger": "5.0.11",
+        "@storybook/components": "5.0.11",
+        "@storybook/theming": "5.0.11",
+        "core-js": "2.6.5",
+        "global": "4.3.2",
+        "marksy": "6.1.0",
+        "nested-object-assign": "1.0.3",
+        "prop-types": "15.7.2",
+        "react": "16.8.6",
+        "react-addons-create-fragment": "15.6.2",
+        "react-element-to-jsx-string": "14.0.2",
+        "react-is": "16.8.6",
+        "react-lifecycles-compat": "3.0.4",
+        "util-deprecate": "1.0.2"
+      }
+    },
     "@storybook/addon-knobs": {
       "version": "5.0.11",
       "resolved": "https://registry.npmjs.org/@storybook/addon-knobs/-/addon-knobs-5.0.11.tgz",
@@ -2098,6 +2121,49 @@
         "@webassemblyjs/ast": "1.8.5",
         "@webassemblyjs/wast-parser": "1.8.5",
         "@xtuc/long": "4.2.2"
+      }
+    },
+    "@webpack-contrib/schema-utils": {
+      "version": "1.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@webpack-contrib/schema-utils/-/schema-utils-1.0.0-beta.0.tgz",
+      "integrity": "sha512-LonryJP+FxQQHsjGBi6W786TQB1Oym+agTpY0c+Kj8alnIw+DLUJb6SI8Y1GHGhLCH1yPRrucjObUmxNICQ1pg==",
+      "dev": true,
+      "requires": {
+        "ajv": "6.10.0",
+        "ajv-keywords": "3.4.0",
+        "chalk": "2.4.2",
+        "strip-ansi": "4.0.0",
+        "text-table": "0.2.0",
+        "webpack-log": "1.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        },
+        "webpack-log": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/webpack-log/-/webpack-log-1.2.0.tgz",
+          "integrity": "sha512-U9AnICnu50HXtiqiDxuli5gLB5PGBo7VvcHx36jRZHwK4vzOYLbImqT4lwWwoMHdQWwEKw736fCHEekokTEKHA==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.4.2",
+            "log-symbols": "2.2.0",
+            "loglevelnext": "1.0.5",
+            "uuid": "3.3.2"
+          }
+        }
       }
     },
     "@xtuc/ieee754": {
@@ -3178,6 +3244,12 @@
           "dev": true
         }
       }
+    },
+    "babel-standalone": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-standalone/-/babel-standalone-6.26.0.tgz",
+      "integrity": "sha1-Ffs9NfLEVmlYFevx7Zb+fwFbaIY=",
+      "dev": true
     },
     "bail": {
       "version": "1.0.4",
@@ -7034,6 +7106,12 @@
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
+    "get-own-enumerable-property-symbols": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-2.0.1.tgz",
+      "integrity": "sha512-TtY/sbOemiMKPRUDDanGCSgBYe7Mf0vbRsWnBZ+9yghpZ1MvcpSpuZFjHdEeY/LZjZy0vdLjS77L6HosisFiug==",
+      "dev": true
+    },
     "get-stdin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
@@ -8135,6 +8213,12 @@
       "integrity": "sha1-8mWrian0RQNO9q/xWo8AsA9VF5k=",
       "dev": true
     },
+    "is-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+      "dev": true
+    },
     "is-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
@@ -8200,6 +8284,12 @@
       "requires": {
         "has": "1.0.3"
       }
+    },
+    "is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
+      "dev": true
     },
     "is-resolvable": {
       "version": "1.1.0",
@@ -8753,6 +8843,25 @@
       "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=",
       "dev": true
     },
+    "log-symbols": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.4.2"
+      }
+    },
+    "loglevelnext": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/loglevelnext/-/loglevelnext-1.0.5.tgz",
+      "integrity": "sha512-V/73qkPuJmx4BcBF19xPBr+0ZRVBhc4POxvZTZdMeXpJ4NItXSJ/MSwuFT0kQJlCbXvdlZoQQ/418bS1y9Jh6A==",
+      "dev": true,
+      "requires": {
+        "es6-symbol": "3.1.1",
+        "object.assign": "4.1.0"
+      }
+    },
     "lolex": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.0.1.tgz",
@@ -8875,6 +8984,23 @@
       "requires": {
         "prop-types": "15.7.2",
         "unquote": "1.1.1"
+      }
+    },
+    "marked": {
+      "version": "0.3.19",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
+      "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
+      "dev": true
+    },
+    "marksy": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/marksy/-/marksy-6.1.0.tgz",
+      "integrity": "sha512-xVAuJQxwdAljvFVqlY7CIRewn5YHGvCqeJkY1bbcTBfZV4dNDSZpHWTREb1MNu/oXYzKgg5pmTfE1DIW6M1zrA==",
+      "dev": true,
+      "requires": {
+        "babel-standalone": "6.26.0",
+        "he": "1.2.0",
+        "marked": "0.3.19"
       }
     },
     "material-colors": {
@@ -9335,6 +9461,12 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
       "integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==",
+      "dev": true
+    },
+    "nested-object-assign": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/nested-object-assign/-/nested-object-assign-1.0.3.tgz",
+      "integrity": "sha512-kgq1CuvLyUcbcIuTiCA93cQ2IJFSlRwXcN+hLcb2qLJwC2qrePHGZZa7IipyWqaWF6tQjdax2pQnVxdq19Zzwg==",
       "dev": true
     },
     "next-tick": {
@@ -10844,6 +10976,17 @@
         "scheduler": "0.13.6"
       }
     },
+    "react-addons-create-fragment": {
+      "version": "15.6.2",
+      "resolved": "https://registry.npmjs.org/react-addons-create-fragment/-/react-addons-create-fragment-15.6.2.tgz",
+      "integrity": "sha1-o5TefCx77Na1R1uhuXrEcs58dPg=",
+      "dev": true,
+      "requires": {
+        "fbjs": "0.8.17",
+        "loose-envify": "1.4.0",
+        "object-assign": "4.1.1"
+      }
+    },
     "react-clientside-effect": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.0.tgz",
@@ -11078,6 +11221,23 @@
         }
       }
     },
+    "react-docgen-typescript": {
+      "version": "1.12.4",
+      "resolved": "https://registry.npmjs.org/react-docgen-typescript/-/react-docgen-typescript-1.12.4.tgz",
+      "integrity": "sha512-OSmUfmdtcz4kLRWPiR8uUdE8ta+s5DV0uXOz1YsWaAUf3Ty64use7DYWK97zH8ZOlD4slq5zUfGc+UbfGLqfEQ==",
+      "dev": true
+    },
+    "react-docgen-typescript-loader": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/react-docgen-typescript-loader/-/react-docgen-typescript-loader-3.1.0.tgz",
+      "integrity": "sha512-gY+b7RkRPty5ZN4NMQ+jwx9MzTVuIj6LJCwdWRAi1+nrHJfH2gMMytQfxFdzQ7BlgD4COWnSE8Ixtl2L62kCRw==",
+      "dev": true,
+      "requires": {
+        "@webpack-contrib/schema-utils": "1.0.0-beta.0",
+        "loader-utils": "1.2.3",
+        "react-docgen-typescript": "1.12.4"
+      }
+    },
     "react-dom": {
       "version": "16.8.6",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.6.tgz",
@@ -11097,6 +11257,16 @@
       "requires": {
         "classnames": "2.2.6",
         "prop-types": "15.7.2"
+      }
+    },
+    "react-element-to-jsx-string": {
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/react-element-to-jsx-string/-/react-element-to-jsx-string-14.0.2.tgz",
+      "integrity": "sha512-eYcPUg3FJisgAb8q3sSdce8F/xMZD/iFEjMZYnkE3b7gPi5OamGr2Hst/1pE72mzn7//dfYPXb+UqPK2xdSGsg==",
+      "dev": true,
+      "requires": {
+        "is-plain-object": "2.0.4",
+        "stringify-object": "3.2.2"
       }
     },
     "react-error-overlay": {
@@ -12957,6 +13127,17 @@
       "dev": true,
       "requires": {
         "safe-buffer": "5.1.2"
+      }
+    },
+    "stringify-object": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.2.2.tgz",
+      "integrity": "sha512-O696NF21oLiDy8PhpWu8AEqoZHw++QW6mUv0UvKZe8gWSdSvMXkiLufK7OmnP27Dro4GU5kb9U7JIO0mBuCRQg==",
+      "dev": true,
+      "requires": {
+        "get-own-enumerable-property-symbols": "2.0.1",
+        "is-obj": "1.0.1",
+        "is-regexp": "1.0.0"
       }
     },
     "strip-ansi": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "library-simplified-reusable-components",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Reusable React components for Library Simplified interfaces",
   "repository": {
     "type": "git",
@@ -29,6 +29,7 @@
     "@babel/core": "^7.4.0",
     "@storybook/addon-a11y": "^5.0.6",
     "@storybook/addon-actions": "^5.0.6",
+    "@storybook/addon-info": "^5.0.11",
     "@storybook/addon-knobs": "^5.0.6",
     "@storybook/addon-links": "^5.0.6",
     "@storybook/addon-storysource": "^5.0.6",
@@ -52,6 +53,7 @@
     "mini-css-extract-plugin": "^0.5.0",
     "mocha": "^5.2.0",
     "node-sass": "^4.11.0",
+    "react-docgen-typescript-loader": "^3.1.0",
     "sass-lint": "^1.9.1",
     "sass-loader": "^7.1.0",
     "sinon": "^7.3.0",

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 export interface ButtonProps {
+  /** The action to perform on the <button>'s onClick function */
   callback: (event: React.MouseEvent) => void;
   content?: string | JSX.Element;
   className?: string;

--- a/stories/index.stories.tsx
+++ b/stories/index.stories.tsx
@@ -1,28 +1,18 @@
 import * as React from 'react';
 
-import { storiesOf, addDecorator } from '@storybook/react';
-import { withKnobs } from '@storybook/addon-knobs';
-import { withA11y } from '@storybook/addon-a11y';
-
-import header from './header.stories';
-import panel from './panel.stories';
-import tabs from './tabs.stories';
-
-import '../node_modules/bootstrap/dist/css/bootstrap.min.css';
-import '../src/stylesheets/app.scss';
-
-const styles = {
-  padding: '20px',
-};
-export const CenterDecorator = storyFn => <div style={styles}>{storyFn()}</div>;
-
-addDecorator(CenterDecorator);
-addDecorator(withKnobs);
-addDecorator(withA11y);
+import { storiesOf } from '@storybook/react';
 
 storiesOf('Home', module)
   .add('introduction', () => 
     <div>
       <h2>NYPL Simplified Reusable Components</h2>
-    </div>
+      <p>
+        Welcome to the documentation for components used in various SimplyE web apps.
+      </p>
+    </div>,
+    {
+      info: {
+        disable: true
+      }
+    }
   );

--- a/stories/panel.stories.tsx
+++ b/stories/panel.stories.tsx
@@ -6,6 +6,33 @@ import Panel from '../src/components/Panel';
 
 const panelContent = <div>Simple panel text</div>;
 const panel = storiesOf('Components/Panel', module)
+  .addParameters({
+    info: {
+      text: `
+        The \`Panel\` component comes with five built-in styles:
+        * "success" (green)
+        * "warning" (yellow)
+        * "danger" (red)
+        * "instruction" (blue)
+        * "default" (gray)
+
+        You can also define your own styles.  If you do not pass in a value for the
+        \`style\` prop, the style will be set to "default".
+
+        Populate the panel via the \`content\` prop. It accepts either a JSX element or an HTML string.
+
+        To make a static (as opposed to a collapsible) \`Panel\`, set the \`collapsible\`
+        prop to false. This will: remove the open/close icon; prevent the panel from
+        opening/closing when the header is clicked; render the header as a div rather
+        than a button; and automatically ensure that the panel is always open
+        (i.e. you do not need to also set the \`openByDefault\` prop).
+
+        By default, a collapsible \`Panel\` will toggle on enter.  To override this
+        behavior--e.g. if the \`Panel\` is inside a form which should submit on enter,
+        pass in the function that you'd like to trigger on enter as the \`onEnter\` prop.
+        `
+    },
+  })
   .add('default', () =>
     <Panel
       headerText={text('headerText', 'Default Panel Title')}


### PR DESCRIPTION
Fixes [SIMPLY-1935](https://jira.nypl.org/browse/SIMPLY-1935).

Pointing this PR to the #14 since the `Info` addon depends on React 16. With this package and some more configuration we can get this for each component:

![Screen Shot 2019-05-07 at 4 59 36 PM](https://user-images.githubusercontent.com/1280564/57333407-c5850c80-70ea-11e9-9908-7efee0225398.png)

I also added a package to better parse each component's inline comments for the nice prop type table. I didn't go crazy adding more comments, however.