### PR TITLE
Fix log-in button font size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v1.3.17
+#### Fixed
+- Resized the font for centered buttons on forms.
+
 ### v1.3.16
 #### Updated
 - Updated the Input component to comply with accessibility standards. Added minor tweaks to the Form component and minor style updates.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "library-simplified-reusable-components",
-  "version": "1.3.16",
+  "version": "1.3.17",
   "description": "Reusable React components for Library Simplified interfaces",
   "repository": {
     "type": "git",

--- a/src/stylesheets/form.scss
+++ b/src/stylesheets/form.scss
@@ -7,7 +7,7 @@ form {
   label {
     margin-right: 10px;
 
-    &.block { 
+    &.block {
       display: block;
     }
   }
@@ -33,6 +33,7 @@ form {
       display: block;
       margin: auto;
       width: 25vw;
+      font-size: 1.2em;
       &:hover {
         border-color: $gray-brown;
       }


### PR DESCRIPTION
Resolves https://jira.nypl.org/browse/SIMPLY-2326; the font on the centered button was way too big.

GIANT MONSTER font:
<img width="961" alt="Screen Shot 2019-11-06 at 12 00 42 PM" src="https://user-images.githubusercontent.com/42178216/68320651-5767d500-008e-11ea-844e-cfe14ea6b2a6.png">

Normal font:
<img width="759" alt="Screen Shot 2019-11-06 at 12 00 47 PM" src="https://user-images.githubusercontent.com/42178216/68320658-5afb5c00-008e-11ea-9b4b-3dfee877cf29.png">
