### PR TITLE
Adds styling for .alert-loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,125 +1,215 @@
 ## Changelog
+
+### v1.3.20
+
+#### Updated
+
+- Updated form.scss so that .alert-loading appears in the same way as
+  .alert-error and .alert-success within the inline class.
+
 ### v1.3.19
+
 #### Updated
+
 - Updated Panel component to optionally accept and execute an onClick prop.
+
 ### v1.3.18
+
 #### Updated
+
 - Updated selected dependencies.
 
 ### v1.3.17
+
 #### Fixed
+
 - Resized the font for centered buttons on forms.
 
 ### v1.3.16
+
 #### Updated
-- Updated the Input component to comply with accessibility standards. Added minor tweaks to the Form component and minor style updates.
+
+- Updated the Input component to comply with accessibility standards. Added
+  minor tweaks to the Form component and minor style updates.
 
 ### v1.3.15
+
 #### Fixed
+
 - Updated ref usage in the Tabs component to fix compatibility issues.
 
 ### v1.3.14
+
 #### Updated
+
 - Updated the Tabs component to comply with accessibility standards.
 
 ### v1.3.13
+
 #### Updated
-- Updated the Panel component to have aria attributes for accessibility. Added a static panel example to the Storybook instance.
-- Added Travis CI hook to deploy Storybook to Github Pages on a successful pass on `master`.
-- Updated the Header component with styling for the logo and optional nav element.
+
+- Updated the Panel component to have aria attributes for accessibility. Added a
+  static panel example to the Storybook instance.
+- Added Travis CI hook to deploy Storybook to Github Pages on a successful pass
+  on `master`.
+- Updated the Header component with styling for the logo and optional nav
+  element.
 
 ### v1.3.12
+
 #### Updated
+
 - Updated the Header and Tabs components for documentation purposes.
 
 ### v1.3.11
+
 #### Updated
-- Updated the Button component to render extra props, for aria-* attributes. Updated related styles for hover state.
+
+- Updated the Button component to render extra props, for aria-\* attributes.
+  Updated related styles for hover state.
 
 ### v1.3.10
+
 #### Added
-- Added `tslint-react-a11y` as a linter extension for checking for accessibility issues in the React components.
+
+- Added `tslint-react-a11y` as a linter extension for checking for accessibility
+  issues in the React components.
+
 #### Updated
+
 - Enabled optionally passing an onMouseDown handler to the Button
 
 ### v1.3.9
+
 #### Updated
+
 - Committed new version of package-lock.json
 
 ### v1.3.8
+
 #### Added
+
 - Updates and stories for the Form
 
 ### v1.3.7
+
 #### Updated
+
 - Committed new version of package-lock.json
 
 ### v1.3.6
+
 #### Added
+
 - More styling options for the Button component
 - More stories for the Button component
 
 ### v1.3.5
+
 #### Added
-- Added `withInfo` Storybook addon to include better documentation for each component.
+
+- Added `withInfo` Storybook addon to include better documentation for each
+  component.
 
 ### v1.3.4
+
 #### Updated
+
 - Now React 16 for the build.
 
 ### v1.3.3
+
 #### Fixed
+
 - Color Contrast issue for the "danger" button style.
+
 #### Added
+
 - Stories for the Button component.
 
 ### v1.3.2
+
 #### Fixed
+
 - Fixed Button styling bug involving text color on focus.
+
 #### Added
-- Enabled optional specification of custom behavior on enter for the Panel component.  This fixes a bug whereby forms containing Panels would toggle the Panel on enter rather than submitting.
+
+- Enabled optional specification of custom behavior on enter for the Panel
+  component. This fixes a bug whereby forms containing Panels would toggle the
+  Panel on enter rather than submitting.
 
 ### v1.3.1
+
 - Added additional configuration options to the Button component.
 
 ### v1.3.0
+
 #### Added
-- Storybook for documentation of the components. A static build can be seen on the [Github repo](https://nypl-simplified.github.io/reusable-components/).
+
+- Storybook for documentation of the components. A static build can be seen on
+  the [Github repo](https://nypl-simplified.github.io/reusable-components/).
 
 ### v1.2.0
+
 #### Updated
-- Updated to Webpack 4! This update also includes updates to many other npm packages.
-- Tests were moved from inside the `src` folder to outside of it, that way Webpack will not include it in the build, as it is not needed in the final distribution.
+
+- Updated to Webpack 4! This update also includes updates to many other npm
+  packages.
+- Tests were moved from inside the `src` folder to outside of it, that way
+  Webpack will not include it in the build, as it is not needed in the final
+  distribution.
+
 #### Added
+
 - Typescript has been updated to v2.7.2 and with that `typings` were removed and
-`@types` were included.
+  `@types` were included.
+
 #### Removed
-- Cleaned up package.json. Many existing npm packages which are not used in this repo have not been removed as dependencies.
-- The `opds-web-client` was removed from this repo as it is not needed and was only used to import scss files. The app breaks without it so one scss variable and one scss mixin were manually moved into this repo.
+
+- Cleaned up package.json. Many existing npm packages which are not used in this
+  repo have not been removed as dependencies.
+- The `opds-web-client` was removed from this repo as it is not needed and was
+  only used to import scss files. The app breaks without it so one scss variable
+  and one scss mixin were manually moved into this repo.
 - `typings` were removed in favor of @types.
 
 ### v1.1.3
+
 #### Fixed
+
 - Fixed a minor styling bug involving the Panel component's behavior on hover
 
 ### v1.1.2
+
 - Added additional configuration options to the Panel component
 
 ### v1.1.1
+
 #### Updated
+
 - Webpack configuration
 
 ### v1.1.0
+
 - Working version to use as a package on npm
+
 #### Added
+
 - Added a file to export components
+
 #### Updated
+
 - Webpack configuration
 
 ### v1.0.0
+
 #### Added
+
 - Created a demo page
 
 ### v0.0.1
+
 #### Added
+
 - Set up the repo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 #### Updated
 
-- Updated form.scss so that .alert-loading appears in the same way as
-  .alert-error and .alert-success within the inline class.
+- Updated form.scss so that `.alert-loading` appears in the same way as
+  `.alert-error` and `.alert-success` within the `inline` class in the Form
+  component.
 
 ### v1.3.19
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "library-simplified-reusable-components",
-  "version": "1.3.19",
+  "version": "1.3.20",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "library-simplified-reusable-components",
-  "version": "1.3.19",
+  "version": "1.3.20",
   "description": "Reusable React components for Library Simplified interfaces",
   "repository": {
     "type": "git",

--- a/src/stylesheets/form.scss
+++ b/src/stylesheets/form.scss
@@ -53,7 +53,8 @@ form {
       border: 0;
     }
 
-    .form-group, fieldset {
+    .form-group,
+    fieldset {
       min-width: 50%;
       flex: 2;
       margin: 0;
@@ -65,7 +66,10 @@ form {
         padding: 6px 12px;
       }
     }
-    .alert-success, .alert-danger, .alert-info {
+    .alert-success,
+    .alert-danger,
+    .alert-info,
+    .alert-loading {
       width: 100%;
       margin-top: 20px;
     }
@@ -95,14 +99,14 @@ form {
     text-align: center;
     width: 80%;
     margin: 1em auto 2em auto;
-    padding-bottom: .5em;
+    padding-bottom: 0.5em;
     border-bottom: 1px solid $blue-dark;
   }
 
   fieldset.well {
     display: inline-block;
     width: 25vw;
-    margin: .5em;
+    margin: 0.5em;
     position: relative;
     legend {
       font-size: 1em;
@@ -138,7 +142,7 @@ form {
     }
     .form-group {
       input.form-control {
-        border-radius: .25em;
+        border-radius: 0.25em;
         padding: 5px;
       }
     }


### PR DESCRIPTION
**Change**
- Added .alert-loading to the inline class block of form.scss

**Reason**
– Adding a loading message to the Library Registry Admin search form, and need it to look the same as the existing messages (success and error). See [SIMPLY-3859](https://jira.nypl.org/browse/SIMPLY-3859).

**Testing**
- Tested this change by running the storybook file with the inline class